### PR TITLE
added support for original pastel colors by conditionally enabling colormixing, and providing a color file …

### DIFF
--- a/colors/original
+++ b/colors/original
@@ -1,0 +1,19 @@
+#define ENABLE_PASTELS
+#define C_MIX                   DWhite
+#define C_TAGBG                 DPalebluegreen
+#define C_TAGFG                 0x000000FF
+#define C_TAGHLBG               DPalegreygreen
+#define C_TAGHLFG               0x000000FF
+
+#define C_TXTBG                 DPaleyellow
+#define C_TXTFG                 0x000000FF
+#define C_TXTHLBG               DDarkyellow
+#define C_TXTHLFG               0x000000FF
+
+#define C_WINBUTTON             DPurpleblue
+#define C_COLBUTTON             DPurpleblue
+#define C_TMPBUTTON             DMedblue
+#define C_SCROLLBG              DYellowgreen
+
+#define C_BUTTON2HL             0xAA0000FF
+#define C_BUTTON3HL             0x006600FF

--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -979,14 +979,21 @@ iconinit(void)
 	Image *tmp;
 
 	if(tagcols[BACK] == nil) {
-
+#ifndef ENABLE_PASTELS
 		tagcols[BACK]	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_TAGBG);
+#else
+		tagcols[BACK] = allocimagemix(display, C_TAGBG, C_MIX);
+#endif
+
 		tagcols[HIGH]	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_TAGHLBG);
 		tagcols[BORD]	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_COLBUTTON);
 		tagcols[TEXT]	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_TAGFG);
 		tagcols[HTEXT]	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_TAGHLFG);
-
+#ifndef ENABLE_PASTELS
 		textcols[BACK] 	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_TXTBG);
+#else
+		textcols[BACK] = allocimagemix(display, C_TXTBG, C_MIX);
+#endif
 		textcols[HIGH] 	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_TXTHLBG);
 		textcols[BORD] 	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_SCROLLBG);
 		textcols[TEXT] 	= allocimage(display, Rect(0,0,1,1), RGBA32, 1, C_TXTFG);


### PR DESCRIPTION
Modified (super minor) acme.c and provided a color file in colors called original - enables the original pastel colors to be recreated, for those of us old folks who love the operational improvements A2k brings, but also love the original retro pastel colors...

These changes:
Add an optional #define ENABLE_PASTELS to the config.h and a #define C_MIX
acme.c has an #ifndef ENABLE_PASTELS that preserves the (your) original behavior else
enables color mixing to recreate the textures that were key to faithfully reproducing the original pastels colors.